### PR TITLE
Upgrade to support 15.5 without warnings

### DIFF
--- a/modules/Title.js
+++ b/modules/Title.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 let titles = []
 
@@ -16,27 +17,25 @@ export function flushTitle() {
   return title
 }
 
-const { oneOfType, string, func } = React.PropTypes
-
-const Title = React.createClass({
-
-  propTypes: {
-    render: oneOfType([ string, func ]).isRequired
-  },
-
-  getInitialState() {
-    return {
+class Title extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
       index: titles.push('') - 1
     }
-  },
+  }
 
   componentWillUnmount() {
     titles.pop()
-  },
+  }
 
-  componentDidMount: updateTitle,
+  componentDidMount() {
+    updateTitle()
+  }
 
-  componentDidUpdate: updateTitle,
+  componentDidUpdate() {
+    updateTitle()
+  }
 
   render() {
     const { render } = this.props
@@ -45,8 +44,12 @@ const Title = React.createClass({
       : render
     return this.props.children || null
   }
+}
 
-})
+const { oneOfType, string, func } = React.PropTypes
+
+Title.propTypes = {
+  render: oneOfType([ string, func ]).isRequired
+}
 
 export default Title
-

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "karma-webpack": "^1.7.0",
     "mocha": "^2.0.1",
     "pretty-bytes": "^2.0.1",
+    "prop-types": "^15.5.6",
     "react": "^0.14.0",
     "react-addons-test-utils": "0.14.0",
     "react-dom": "^0.14.0",


### PR DESCRIPTION
Tests are still throwing a propType warning:

`ERROR: 'Warning: You are manually calling a React.PropTypes validation function for the `render` prop on `Title`. `

I don't see anything off-hand. Perhaps you do?

Anyway, no warnings at runtime, tests are passing, and it's working fine in my tests.

This is to resolve #4.